### PR TITLE
Update Gradle to v9.4.0 and Resolve Plugin Compatibility

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -80,6 +80,19 @@ testing {
                 implementation(gradleKotlinDsl())
             }
         }
+        all {
+            dependencies {
+                implementation(libs.gradle.public.api) {
+                    capabilities {
+                        requireCapability("org.gradle.experimental:gradle-public-api-internal")
+                    }
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_API))
+                        attribute(GradlePluginApiVersion.GRADLE_PLUGIN_API_VERSION_ATTRIBUTE, objects.named("9.3.1"))
+                    }
+                }
+            }
+        }
         register<JvmTestSuite>("functionalTest") {
             dependencies {
                 implementation(libs.assertj.core)
@@ -143,6 +156,15 @@ val testKitGradleMinVersionRuntimeOnly by configurations.registering
 dependencies {
     compileOnly(libs.android.gradleApi)
     compileOnly(libs.kotlin.gradlePluginApi)
+    compileOnly(libs.gradle.public.api) {
+        capabilities {
+            requireCapability("org.gradle.experimental:gradle-public-api-internal")
+        }
+        attributes {
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_API))
+            attribute(GradlePluginApiVersion.GRADLE_PLUGIN_API_VERSION_ATTRIBUTE, objects.named("9.3.1"))
+        }
+    }
     compileOnly(libs.jetbrains.annotations)
 
     implementation(libs.sarif4k)

--- a/detekt-gradle-plugin/gradle.properties
+++ b/detekt-gradle-plugin/gradle.properties
@@ -2,3 +2,4 @@ kotlin.stdlib.default.dependency=false
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
 kotlin.compiler.runViaBuildToolsApi=true
 dependency.analysis.print.build.health=true
+org.gradle.unsafe.suppress-gradle-api=true

--- a/detekt-gradle-plugin/settings.gradle.kts
+++ b/detekt-gradle-plugin/settings.gradle.kts
@@ -9,6 +9,14 @@ dependencyResolutionManagement {
     repositories {
         exclusiveContent {
             forRepository {
+                maven("https://repo.gradle.org/artifactory/libs-releases/")
+            }
+            filter {
+                includeGroup("org.gradle.experimental")
+            }
+        }
+        exclusiveContent {
+            forRepository {
                 google()
             }
             filter {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 coroutines = "1.10.2"
 jacoco = "0.8.14"
+gradle-experimental = "9.3.1"
 junit = "6.0.3"
 kotlin = "2.3.10"
 ktlint = "1.8.0"
@@ -30,6 +31,8 @@ junit-jupiterApi = { module = "org.junit.jupiter:junit-jupiter-api", version = "
 # This represents the oldest Kotlin version that is supported by detekt's Gradle plugin.
 # This should only be updated when updating the minimum version supported by detekt's Gradle plugin.
 kotlin-gradlePluginApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version = "2.1.0" }
+
+gradle-public-api = { module = "org.gradle.experimental:gradle-public-api", version.ref = "gradle-experimental" }
 
 assertj-core = { module = "org.assertj:assertj-core", version = "3.27.7" }
 # This represents the oldest assertj version supported by detekt-test-assertj.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=b266d5ff6b90eada6dc3b20cb090e3731302e553a27c5d3e4df1f0d76beaff06
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionSha256Sum=60ea723356d81263e8002fec0fcf9e2b0eee0c0850c7a3d7ab0a63f2ccc601f3
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,10 @@ rootProject.name = "detekt"
 pluginManagement {
     includeBuild("build-logic")
     includeBuild("detekt-gradle-plugin")
+    repositories {
+        maven("https://repo.gradle.org/artifactory/libs-releases/")
+        gradlePluginPortal()
+    }
 }
 
 include("code-coverage-report")
@@ -83,6 +87,14 @@ buildCache {
 dependencyResolutionManagement {
     repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
     repositories {
+        exclusiveContent {
+            forRepository {
+                maven("https://repo.gradle.org/artifactory/libs-releases/")
+            }
+            filter {
+                includeGroup("org.gradle.experimental")
+            }
+        }
         exclusiveContent {
             forRepository {
                 // Remove when this is closed: https://youtrack.jetbrains.com/issue/KT-56203/AA-Publish-analysis-api-standalone-and-dependencies-to-Maven-Central


### PR DESCRIPTION
Updated the project to Gradle 9.4.0 while resolving build blockages in `detekt-gradle-plugin` caused by Kotlin version mismatches. The solution uses the experimental published Gradle API and suppresses the default `gradleApi()` injection to ensure compatibility across Gradle versions.

---
*PR created automatically by Jules for task [12332952017398890976](https://jules.google.com/task/12332952017398890976) started by @3flex*