### PR TITLE
Publish source JARs for analysis API shadow modules

### DIFF
--- a/detekt-kotlin-analysis-api-standalone/build.gradle.kts
+++ b/detekt-kotlin-analysis-api-standalone/build.gradle.kts
@@ -14,6 +14,27 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
+val sourcesJar by tasks.registering(Jar::class) {
+    archiveClassifier.set("sources")
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    from(provider {
+        configurations.runtimeClasspath.get().incoming.artifactView {
+            withVariantReselection()
+            attributes {
+                attribute(Category.CATEGORY_ATTRIBUTE, objects.named<Category>(Category.DOCUMENTATION))
+                attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named<DocsType>(DocsType.SOURCES))
+            }
+            lenient(true)
+        }.files.map { zipTree(it) }
+    })
+}
+
+publishing {
+    publications.named<MavenPublication>(DETEKT_PUBLICATION) {
+        artifact(sourcesJar)
+    }
+}
+
 val javaComponent = components["java"] as AdhocComponentWithVariants
 javaComponent.withVariantsFromConfiguration(configurations["apiElements"]) {
     skip()

--- a/detekt-kotlin-analysis-api/build.gradle.kts
+++ b/detekt-kotlin-analysis-api/build.gradle.kts
@@ -29,6 +29,27 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
+val sourcesJar by tasks.registering(Jar::class) {
+    archiveClassifier.set("sources")
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    from(provider {
+        configurations.runtimeClasspath.get().incoming.artifactView {
+            withVariantReselection()
+            attributes {
+                attribute(Category.CATEGORY_ATTRIBUTE, objects.named<Category>(Category.DOCUMENTATION))
+                attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named<DocsType>(DocsType.SOURCES))
+            }
+            lenient(true)
+        }.files.map { zipTree(it) }
+    })
+}
+
+publishing {
+    publications.named<MavenPublication>(DETEKT_PUBLICATION) {
+        artifact(sourcesJar)
+    }
+}
+
 val javaComponent = components["java"] as AdhocComponentWithVariants
 javaComponent.withVariantsFromConfiguration(configurations["apiElements"]) {
     skip()


### PR DESCRIPTION
Create combined source JARs for detekt-kotlin-analysis-api and
detekt-kotlin-analysis-api-standalone by collecting source artifacts
from bundled dependencies using Gradle's ArtifactView with variant
reselection. This enables IDE navigation and documentation for
consumers of these repackaged modules.

Closes #8979

Co-authored-by: Claude <claude@anthropic.com>

https://claude.ai/code/session_01R7KmHW6eqDJK3FNpEA47yc