### PR TITLE
Publish shadow JAR for detekt-rules-ktlint-wrapper (#9177)

### DIFF
--- a/build-logic/src/main/kotlin/releasing.gradle.kts
+++ b/build-logic/src/main/kotlin/releasing.gradle.kts
@@ -50,8 +50,7 @@ dependencies {
         targetConfiguration = "shadow" // com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin.CONFIGURATION_NAME
     }
     releaseArtifacts(project(":detekt-rules-ktlint-wrapper")) {
-        targetConfiguration = Dependency.DEFAULT_CONFIGURATION
-        isTransitive = false
+        targetConfiguration = "shadow" // com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin.CONFIGURATION_NAME
     }
     releaseArtifacts(project(":detekt-rules-libraries")) {
         targetConfiguration = Dependency.DEFAULT_CONFIGURATION

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     testImplementation(libs.assertj.core)
     testRuntimeOnly(projects.detektRulesKtlintWrapper)
 
-    pluginsJar(projects.detektRulesKtlintWrapper)
+    pluginsJar(project(":detekt-rules-ktlint-wrapper", "shadow"))
     pluginsJar(projects.detektRulesLibraries)
     pluginsJar(projects.detektRulesRuleauthors)
 }

--- a/detekt-rules-ktlint-wrapper/build.gradle.kts
+++ b/detekt-rules-ktlint-wrapper/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("module")
+    id("com.gradleup.shadow") version "9.4.1"
 }
 
 val extraDepsToPackage by configurations.registering
@@ -39,19 +40,21 @@ consumeGeneratedConfig(
     forTask = tasks.processResources
 )
 
-val depsToPackage = setOf(
-    "org.ec4j.core",
-    "com.pinterest.ktlint",
-    "io.github.oshai",
-)
+shadow {
+    addShadowVariantIntoJavaComponent = false
+}
 
-tasks.jar {
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE // allow duplicates
-    dependsOn(configurations.runtimeClasspath, extraDepsToPackage)
-    from(
-        configurations.runtimeClasspath.get()
-            .filter { dependency -> depsToPackage.any { it in dependency.toString() } }
-            .map { if (it.isDirectory) it else zipTree(it) },
-        extraDepsToPackage.get().map { zipTree(it) },
+publishing {
+    publications.named<MavenPublication>(DETEKT_PUBLICATION) {
+        artifact(tasks.shadowJar)
+    }
+}
+
+tasks.shadowJar {
+    configurations = listOf(
+        project.configurations.runtimeClasspath.get(),
+        extraDepsToPackage.get()
     )
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    mergeServiceFiles()
 }


### PR DESCRIPTION
Replace the custom `tasks.jar` fat-jar bundling with the shadow plugin
to properly publish a `-all.jar` artifact. The previous approach used a
file-path-based filter that failed to match ktlint-repackage's shadow
JAR, causing NoClassDefFoundError for CLI users.

Co-authored-by: Claude <claude@anthropic.com>

https://claude.ai/code/session_01YRbzgc8vW17zpKoA8q4EM7