### PR TITLE
Pin DGP compile-time Gradle API to 8.14.3 and bump wrapper to 9.4.1

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -32,6 +32,15 @@ buildConfig {
     buildConfigField("KOTLIN_IMPLEMENTATION_VERSION", libs.versions.kotlin.get())
 }
 
+// Drop the gradleApi() dependency that java-gradle-plugin contributes to the api configuration.
+// We pin the compile-time Gradle API via org.gradle.experimental:gradle-public-api so the
+// build-time Gradle distribution's Kotlin stdlib version no longer drives DGP's compile classpath.
+configurations.named("api").configure {
+    dependencies.removeIf { dep ->
+        dep is FileCollectionDependency && dep.files.toString().contains("gradle-api")
+    }
+}
+
 nexusPublishing {
     repositories {
         create("sonatype") {
@@ -143,6 +152,7 @@ val testKitGradleMinVersionRuntimeOnly by configurations.registering
 dependencies {
     compileOnly(libs.android.gradleApi)
     compileOnly(libs.kotlin.gradlePluginApi)
+    compileOnly(libs.gradle.publicApi)
     compileOnly(libs.jetbrains.annotations)
 
     implementation(libs.sarif4k)

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -128,6 +128,10 @@ kotlin {
     @OptIn(ExperimentalBuildToolsApi::class, ExperimentalKotlinGradlePluginApi::class)
     compilerVersion = "2.1.21"
 
+    // Pin the kotlin-stdlib (and friends) added by the Kotlin Gradle plugin to match compilerVersion,
+    // so DGP's compile classpath does not receive stdlib 2.3 metadata that Kotlin 2.1 cannot read.
+    coreLibrariesVersion = "2.1.21"
+
     compilerOptions {
         suppressWarnings = true
         // Note: Currently there are warnings for detekt-gradle-plugin that seemingly can't be fixed

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -41,6 +41,18 @@ configurations.named("api").configure {
     }
 }
 
+// Force kotlin-stdlib* to match the pinned compilerVersion. coreLibrariesVersion only sets the
+// KGP default; transitive deps (e.g. KGP-API, sarif4k) can still pull stdlib 2.3, whose metadata
+// the Kotlin 2.1.21 compiler cannot read.
+configurations.configureEach {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.jetbrains.kotlin" && requested.name.startsWith("kotlin-stdlib")) {
+            useVersion("2.1.21")
+            because("DGP compiles with Kotlin 2.1.21; stdlib metadata must be readable by the 2.1 compiler")
+        }
+    }
+}
+
 nexusPublishing {
     repositories {
         create("sonatype") {

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -152,7 +152,11 @@ val testKitGradleMinVersionRuntimeOnly by configurations.registering
 dependencies {
     compileOnly(libs.android.gradleApi)
     compileOnly(libs.kotlin.gradlePluginApi)
-    compileOnly(libs.gradle.publicApi)
+    compileOnly(libs.gradle.publicApi) {
+        capabilities {
+            requireCapability("org.gradle.experimental:gradle-public-api-internal")
+        }
+    }
     compileOnly(libs.jetbrains.annotations)
 
     implementation(libs.sarif4k)

--- a/detekt-gradle-plugin/settings.gradle.kts
+++ b/detekt-gradle-plugin/settings.gradle.kts
@@ -17,6 +17,17 @@ dependencyResolutionManagement {
                 includeGroup("com.google.testing.platform")
             }
         }
+        exclusiveContent {
+            forRepository {
+                maven("https://repo.gradle.org/artifactory/libs-releases/") {
+                    name = "GradleLibsReleases"
+                    mavenContent { releasesOnly() }
+                }
+            }
+            filter {
+                includeGroup("org.gradle.experimental")
+            }
+        }
         mavenCentral()
     }
 

--- a/detekt-sample-extensions/gradle/wrapper/gradle-wrapper.properties
+++ b/detekt-sample-extensions/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 agp = "9.1.0"
 coroutines = "1.10.2"
+gradle-publicApi = "8.14.3"
 jacoco = "0.8.14"
 junit = "6.0.3"
 kotlin = "2.3.20"
@@ -25,6 +26,10 @@ kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", v
 # This should only be updated when updating the minimum version supported by detekt's Gradle plugin.
 # This should be set to an 8.x version, however DGP checks android.enableKotlin DSL property which is only in AGP 9 API
 android-gradleApi = { module = "com.android.tools.build:gradle-api", version = "9.0.0" }
+
+# Gradle's experimental public API publication (see https://github.com/gradle/gradle/issues/29483).
+# Pinned so DGP compiles against a fixed Gradle API version, independent of the build-time Gradle.
+gradle-publicApi = { module = "org.gradle.experimental:gradle-public-api", version.ref = "gradle-publicApi" }
 
 # This represents the oldest JUnit version supported by detekt-test-junit.
 # This should only be updated when updating the minimum version supported by detekt-test-junit.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=b266d5ff6b90eada6dc3b20cb090e3731302e553a27c5d3e4df1f0d76beaff06
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionSha256Sum=2ab2958f2a1e51120c326cad6f385153bb11ee93b3c216c5fccebfdfbb7ec6cb
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Gradle 9.4 embeds Kotlin 2.3, which the DGP's Kotlin 2.1.21 compiler
(configured with -api-version 1.7 for Gradle 7.6.3 compatibility) cannot
read. Replace the implicit gradleApi() dependency contributed by the
java-gradle-plugin with org.gradle.experimental:gradle-public-api:8.14.3,
resolved from https://repo.gradle.org/artifactory/libs-releases/, so the
build-time Gradle distribution no longer drives DGP's compile classpath.

Refs detekt/detekt#9113, gradle/gradle#29483.

Co-authored-by: Claude <claude@anthropic.com>