### PR TITLE
fix: resolve extension callables invoked via dot notation in UnusedImport (#9269)

### DIFF
--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnusedImport.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnusedImport.kt
@@ -10,6 +10,9 @@ import dev.detekt.api.Rule
 import dev.detekt.api.config
 import dev.detekt.psi.isPartOf
 import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.resolution.KaCallableMemberCall
+import org.jetbrains.kotlin.analysis.api.resolution.successfulCallOrNull
+import org.jetbrains.kotlin.analysis.api.resolution.symbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaCallableSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaClassKind
 import org.jetbrains.kotlin.analysis.api.symbols.KaClassLikeSymbol
@@ -18,7 +21,9 @@ import org.jetbrains.kotlin.analysis.api.symbols.KaSymbol
 import org.jetbrains.kotlin.idea.references.mainReference
 import org.jetbrains.kotlin.kdoc.psi.impl.KDocTag
 import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.kotlin.psi.KtImportList
@@ -63,7 +68,20 @@ class UnusedImport(config: Config) :
             staticReferences.mapTo(mutableSetOf()) { it.text.trim('`') }
         }
         private val fqNames: Set<FqName> by lazy {
-            namedReferences.mapNotNullTo(mutableSetOf()) { it.fqNameOrNull() }
+            buildSet {
+                namedReferences.mapNotNullTo(this) { it.fqNameOrNull() }
+                // For extension callables invoked via dot notation (e.g. `Dispatchers.IO`
+                // where `IO` is an extension property on `Dispatchers`), resolving the
+                // selector alone may not produce the canonical import FQN - notably on
+                // KMP where the extension is an `expect` declaration (issue #9269).
+                // Also resolve each dot-qualified expression as a call and add the FQN
+                // of the invoked callable.
+                staticReferences.mapNotNullTo(this) { ref ->
+                    (ref.parent as? KtDotQualifiedExpression)
+                        ?.takeIf { it.receiverExpression == ref }
+                        ?.callableFqNameOrNull()
+                }
+            }
         }
 
         /**
@@ -169,7 +187,11 @@ class UnusedImport(config: Config) :
                     else -> classId
                 }?.asSingleFqName()
 
-                is KaCallableSymbol -> callableId?.asSingleFqName()
+                // Prefer the PSI-based FQN for callable declarations in source: it
+                // matches the canonical import path even for extension callables,
+                // where `callableId.asSingleFqName()` may not round-trip reliably.
+                is KaCallableSymbol ->
+                    (psi as? KtCallableDeclaration)?.fqName ?: callableId?.asSingleFqName()
 
                 else -> null
             }
@@ -177,6 +199,15 @@ class UnusedImport(config: Config) :
         private fun KtReferenceExpression.fqNameOrNull(): FqName? =
             analyze(this) {
                 mainReference.resolveToSymbol()?.fqNameForImport
+            }
+
+        private fun KtDotQualifiedExpression.callableFqNameOrNull(): FqName? =
+            analyze(this) {
+                resolveToCall()
+                    ?.successfulCallOrNull<KaCallableMemberCall<*, *>>()
+                    ?.partiallyAppliedSymbol
+                    ?.symbol
+                    ?.fqNameForImport
             }
     }
 

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnusedImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnusedImportSpec.kt
@@ -942,4 +942,50 @@ class UnusedImportSpec(val env: KotlinEnvironmentContainer) {
             .singleElement()
             .hasMessage("The import 'kotlin.io.path.Path' is unused.")
     }
+
+    @Test
+    fun `does not report extension property accessed via dot notation - #9269`() {
+        val main =
+            """
+            import kotlinx.coroutines.Dispatchers
+            import kotlinx.coroutines.IO
+
+            fun foo() {
+                println(Dispatchers.IO)
+            }
+            """.trimIndent()
+        val coroutines =
+            """
+            package kotlinx.coroutines
+
+            object Dispatchers
+            val Dispatchers.IO: String get() = "io"
+            """.trimIndent()
+        assertThat(subject.lintWithContext(env, main, coroutines)).isEmpty()
+    }
+
+    @Test
+    fun `does report unused extension property import alongside used one - #9269`() {
+        val main =
+            """
+            import kotlinx.coroutines.Dispatchers
+            import kotlinx.coroutines.IO
+            import kotlinx.coroutines.Default
+
+            fun foo() {
+                println(Dispatchers.IO)
+            }
+            """.trimIndent()
+        val coroutines =
+            """
+            package kotlinx.coroutines
+
+            object Dispatchers
+            val Dispatchers.IO: String get() = "io"
+            val Dispatchers.Default: String get() = "default"
+            """.trimIndent()
+        assertThat(subject.lintWithContext(env, main, coroutines))
+            .singleElement()
+            .hasMessage("The import 'kotlinx.coroutines.Default' is unused.")
+    }
 }


### PR DESCRIPTION
`UnusedImport` was flagging `import kotlinx.coroutines.IO` as unused when
`Dispatchers.IO` is used on Kotlin Multiplatform, where `IO` is an
extension property rather than a member of the companion. Two adjustments
together handle the case:

- `fqNameForImport` for `KaCallableSymbol` now prefers the PSI-based
  `KtCallableDeclaration.fqName` when available. For extension callables
  declared in source this is the canonical import path, avoiding any
  mismatch from `callableId.asSingleFqName()`.
- `fqNames` now also collects the FQN of each dot-qualified expression
  by resolving it as a call. This provides a second resolution path that
  captures the invoked callable's identity regardless of how the selector
  alone would resolve.

Regression tests cover both the positive case (import kept) and the
negative case (a sibling unused extension import is still reported).

Co-authored-by: Claude <claude@anthropic.com>