### PR TITLE
Upgrade Gradle wrapper to version 9.6.0-rc-1

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -33,7 +33,7 @@ jobs:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Check build health
-        run: ./gradlew buildHealth :detekt-gradle-plugin:buildHealth
+        run: ./gradlew buildHealth :detekt-gradle-plugin:buildHealth --warning-mode all
 
   gradle:
     strategy:
@@ -63,10 +63,10 @@ jobs:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Assemble and publish artifacts to Maven Local
-        run: ./gradlew publishToMavenLocal
+        run: ./gradlew publishToMavenLocal --warning-mode all
 
       - name: Build detekt
-        run: ./gradlew build -x detekt
+        run: ./gradlew build -x detekt --warning-mode all
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -92,7 +92,7 @@ jobs:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Verify Generated Detekt Config File
-        run: ./gradlew verifyGeneratorOutput
+        run: ./gradlew verifyGeneratorOutput --warning-mode all
 
   compile-test-snippets:
     runs-on: ubuntu-latest
@@ -112,7 +112,7 @@ jobs:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Build and compile test snippets
-        run: ./gradlew test -Pcompile-test-snippets=true
+        run: ./gradlew test -Pcompile-test-snippets=true --warning-mode all
 
   warnings-as-errors:
     runs-on: ubuntu-latest
@@ -132,7 +132,7 @@ jobs:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Run with allWarningsAsErrors
-        run: ./gradlew compileKotlin compileTestKotlin compileTestFixturesKotlin -PwarningsAsErrors=true
+        run: ./gradlew compileKotlin compileTestKotlin compileTestFixturesKotlin -PwarningsAsErrors=true --warning-mode all
 
   build-detekt-sample-extensions:
     runs-on: ubuntu-latest
@@ -142,5 +142,5 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build sample extensions
-        run: ./gradlew build
+        run: ./gradlew build --warning-mode all
         working-directory: detekt-sample-extensions

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektTaskDslSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektTaskDslSpec.kt
@@ -347,7 +347,7 @@ class DetektTaskDslSpec {
             @Test
             fun `fails the build`() {
                 gradleRunner.runDetektTaskAndExpectFailure { result ->
-                    assertThat(result.output).contains("Cannot write a file to a location pointing at a directory.")
+                    assertThat(result.output).contains("Cannot write a file to a location pointing at a directory")
                 }
             }
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-rc-1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -44,6 +44,7 @@ include("detekt-utils")
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
+enableFeaturePreview("NO_IMPLICIT_LOOKUP_IN_PARENT_PROJECTS")
 
 plugins {
     id("com.gradle.develocity") version "4.4.2"


### PR DESCRIPTION
Updated the Gradle distribution URL to version 9.6.0-rc-1.

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
