### PR TITLE
Check if -Xannotations-in-metadata triggers build-health issues in Kotlin 2.3.20

### DIFF
--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -74,6 +74,7 @@ kotlin {
             // Only enable progressive mode in non-DGP modules. DGP doesn't compile with latest language version so
             // progressive mode is not appropriate.
             progressiveMode = true
+            freeCompilerArgs.add("-Xannotations-in-metadata")
         } else {
             freeCompilerArgs.add("-Xjvm-default=all")
         }


### PR DESCRIPTION
…lin 2.3.20

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
